### PR TITLE
Story STORY-UI-005: Add text input validation styling for SettingsPanel

### DIFF
--- a/src/HungryGhostLimiter/Source/ui/SettingsPanel.h
+++ b/src/HungryGhostLimiter/Source/ui/SettingsPanel.h
@@ -48,6 +48,7 @@ public:
         apiKeyInput.setColour(juce::TextEditor::outlineColourId, juce::Colours::white.withAlpha(0.2f));
         apiKeyInput.setColour(juce::TextEditor::focusedOutlineColourId, Style::theme().accent1);
         apiKeyInput.setColour(juce::TextEditor::textColourId, juce::Colours::white);
+        apiKeyInput.onTextChange = [this]() { updateValidationState(); };
         addAndMakeVisible(apiKeyInput);
 
         errorLabel.setText("", juce::dontSendNotification);
@@ -214,6 +215,7 @@ private:
             if (storedKey.isNotEmpty())
                 apiKeyInput.setText(storedKey, juce::dontSendNotification);
         }
+        updateValidationState();
     }
 
     void toggleTheme()
@@ -249,6 +251,37 @@ private:
             auto variant = (themeStr == "light") ? Style::Variant::Light : Style::Variant::Dark;
             Style::setVariant(variant);
             themeToggle.setToggleState(variant == Style::Variant::Light, juce::dontSendNotification);
+        }
+    }
+
+
+    void updateValidationState()
+    {
+        bool isValid = getApiKey().isNotEmpty();
+
+        // Update outline color based on validation state
+        if (isValid)
+        {
+            // Valid: green color
+            apiKeyInput.setColour(juce::TextEditor::outlineColourId, juce::Colour(0xFF4CAF50).withAlpha(0.8f));
+        }
+        else
+        {
+            // Invalid: subtle neutral color
+            apiKeyInput.setColour(juce::TextEditor::outlineColourId, juce::Colours::white.withAlpha(0.2f));
+        }
+
+        // Update save button state
+        saveButton.setEnabled(isValid);
+
+        // Update button appearance when disabled
+        if (!isValid)
+        {
+            saveButton.setColour(juce::TextButton::buttonColourId, juce::Colours::grey.withAlpha(0.5f));
+        }
+        else
+        {
+            saveButton.setColour(juce::TextButton::buttonColourId, Style::theme().accent2);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds dynamic validation styling to the API key input field in SettingsPanel (HungryGhostLimiter) to provide clear visual feedback during data entry.

**Key improvements:**
- **Dynamic validation feedback** - Input border color changes based on validation state
- **Green border (0xFF4CAF50)** when API key is valid (non-empty input)
- **Neutral border (white 0.2 alpha)** when input is empty
- **Save button state management** - Automatically disabled until valid input provided
- **Grey button styling** when save is disabled for clear affordance
- **Real-time validation** via `onTextChange` listener

## Implementation Details

Added `updateValidationState()` method that:
1. Validates API key input (currently checks for non-empty)
2. Updates `TextEditor` outline color dynamically (green for valid, neutral for invalid)
3. Enables/disables Save button based on validation state
4. Updates button color (accent2 when enabled, grey when disabled)

The method is called:
- On every text change via `apiKeyInput.onTextChange` listener (line 51)
- On plugin startup in `loadApiKey()` to initialize state (line 218)

## Files Modified

- `src/HungryGhostLimiter/Source/ui/SettingsPanel.h` - Added 33 lines for validation

## Acceptance Criteria

- ✓ Text input shows focus state clearly (existing accent1 cyan on focus)
- ✓ Invalid/empty input indicated with neutral white border
- ✓ Valid input indicated with green border
- ✓ Placeholder text guides users ('Enter API key...')
- ✓ Save button disabled until valid input provided
- ✓ Clear visual distinction between enabled/disabled save button

## Test Plan

- [x] Code review of validation logic
- [x] Verify `updateValidationState()` correctly updates colors
- [x] Verify button enable/disable logic
- [ ] Build HungryGhostLimiter and test API key input flow
- [ ] Visual test: Verify green border appears when typing
- [ ] Visual test: Verify neutral border when field is cleared
- [ ] Verify save button cannot be clicked when empty
- [ ] Verify smooth color transitions during typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)