### PR TITLE
feat(STORY-MBL-007): Add UI metering components to HungryGhostMultibandLimiter

### DIFF
--- a/src/HungryGhostMultibandLimiter/Source/PluginEditor.cpp
+++ b/src/HungryGhostMultibandLimiter/Source/PluginEditor.cpp
@@ -6,6 +6,13 @@
 HungryGhostMultibandLimiterAudioProcessorEditor::HungryGhostMultibandLimiterAudioProcessorEditor(HungryGhostMultibandLimiterAudioProcessor& p)
     : AudioProcessorEditor(&p), processor(p)
 {
+    // STORY-MBL-007: Create and display metering panel
+    metersPanel = std::make_unique<MetersPanel>();
+    addAndMakeVisible(*metersPanel);
+
+    // Start timer for meter updates at 60 Hz
+    startTimerHz(60);
+
     setSize(800, 600);
 }
 
@@ -20,5 +27,28 @@ void HungryGhostMultibandLimiterAudioProcessorEditor::paint(juce::Graphics& g)
 
 void HungryGhostMultibandLimiterAudioProcessorEditor::resized()
 {
-    // Placeholder: layout will be implemented in STORY-MBL-006 (UI layout)
+    // STORY-MBL-007: Layout meters panel at top of editor
+    if (metersPanel)
+        metersPanel->setBounds(0, 0, getWidth(), 60);
+}
+
+//==============================================================================
+
+void HungryGhostMultibandLimiterAudioProcessorEditor::timerCallback()
+{
+    // STORY-MBL-007: Feed processor metering data to UI at 60 Hz
+    if (!metersPanel)
+        return;
+
+    // Per-band data (2 bands for M1)
+    for (int b = 0; b < 2; ++b)
+    {
+        metersPanel->setBandInputDb(b, processor.getBandInputDb(b));
+        metersPanel->setBandGrDb(b, processor.getBandGainReductionDb(b));
+        metersPanel->setBandOutputDb(b, processor.getBandOutputDb(b));
+    }
+
+    // Master levels
+    metersPanel->setMasterInputDb(processor.getMasterInputDb());
+    metersPanel->setMasterOutputDb(processor.getMasterOutputDb());
 }

--- a/src/HungryGhostMultibandLimiter/Source/PluginEditor.h
+++ b/src/HungryGhostMultibandLimiter/Source/PluginEditor.h
@@ -7,10 +7,11 @@
 #pragma once
 #include <JuceHeader.h>
 #include "PluginProcessor.h"
+#include "ui/MetersPanel.h"
 
 //==============================================================================
 
-class HungryGhostMultibandLimiterAudioProcessorEditor : public juce::AudioProcessorEditor
+class HungryGhostMultibandLimiterAudioProcessorEditor : public juce::AudioProcessorEditor, private juce::Timer
 {
 public:
     explicit HungryGhostMultibandLimiterAudioProcessorEditor(HungryGhostMultibandLimiterAudioProcessor&);
@@ -21,6 +22,12 @@ public:
 
 private:
     HungryGhostMultibandLimiterAudioProcessor& processor;
+
+    // STORY-MBL-007: Metering panel with per-band and master levels
+    std::unique_ptr<MetersPanel> metersPanel;
+
+    // Timer for updating meter data from processor
+    void timerCallback() override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HungryGhostMultibandLimiterAudioProcessorEditor)
 };

--- a/src/HungryGhostMultibandLimiter/Source/ui/GRMeter.h
+++ b/src/HungryGhostMultibandLimiter/Source/ui/GRMeter.h
@@ -1,0 +1,82 @@
+#pragma once
+#include <JuceHeader.h>
+#include <Styling/Theme.h>
+
+/** GRMeter: Gain Reduction meter with red-orange gradient visualization
+    Displays dB of reduction (0-12 dB range typical for limiters)
+    Features attack/release smoothing for visual feedback */
+class GRMeter : public juce::Component, private juce::Timer
+{
+public:
+    GRMeter() { setSmoothing(40.0f, 140.0f); }
+
+    /** Feed dB value (0-12 dB range, will be clamped) */
+    void setGRdB(float db)
+    {
+        targetDb = juce::jlimit(0.0f, 12.0f, db);
+        if (!isTimerRunning()) startTimerHz(30);
+    }
+
+    /** Configure attack/release smoothing times */
+    void setSmoothing(float attackMs, float releaseMs)
+    {
+        atkMs = juce::jmax(1.0f, attackMs);
+        relMs = juce::jmax(1.0f, releaseMs);
+    }
+
+    void paint(juce::Graphics& g) override
+    {
+        auto& th = ::Style::theme();
+        auto bounds = getLocalBounds().toFloat();
+
+        // Track background (dark gradient)
+        juce::ColourGradient trackGrad(th.trackTop, bounds.getX(), bounds.getY(),
+                                       th.trackBot, bounds.getX(), bounds.getBottom(), false);
+        g.setGradientFill(trackGrad);
+        g.fillRoundedRectangle(bounds, 3.0f);
+
+        // GR fill (red-orange gradient, bottom-up)
+        const float normalizedGR = juce::jlimit(0.0f, 1.0f, dispDb / 12.0f);
+        if (normalizedGR > 0.001f)
+        {
+            juce::Graphics::ScopedSaveState scoped(g);
+            juce::Path clipPath;
+            clipPath.addRoundedRectangle(bounds, 3.0f);
+            g.reduceClipRegion(clipPath);
+
+            juce::ColourGradient fillGrad(juce::Colour(0xFFFF6B35),  // Orange
+                                          bounds.getX(), bounds.getY(),
+                                          juce::Colour(0xFFCC3300),   // Red
+                                          bounds.getX(), bounds.getBottom(), false);
+            g.setGradientFill(fillGrad);
+
+            juce::Rectangle<float> fill = bounds;
+            fill.removeFromTop(bounds.getHeight() * (1.0f - normalizedGR));
+            g.fillRect(fill);
+        }
+
+        // Reference line at 0 dB (top)
+        g.setColour(juce::Colour(0xFF666666).withAlpha(0.3f));
+        g.drawHorizontalLine((int)bounds.getY(), bounds.getX(), bounds.getRight());
+    }
+
+    void resized() override {}
+
+private:
+    void timerCallback() override
+    {
+        constexpr float dtMs = 1000.0f / 30.0f;
+        const bool rising = (targetDb > dispDb);
+        const float tau = rising ? atkMs : relMs;
+        const float alpha = 1.0f - std::exp(-dtMs / juce::jmax(1.0f, tau));
+        dispDb += alpha * (targetDb - dispDb);
+
+        if (std::abs(targetDb - dispDb) < 0.001f) stopTimer();
+        repaint();
+    }
+
+    float targetDb{0.0f}, dispDb{0.0f};
+    float atkMs{40.0f}, relMs{140.0f};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GRMeter)
+};

--- a/src/HungryGhostMultibandLimiter/Source/ui/MetersPanel.h
+++ b/src/HungryGhostMultibandLimiter/Source/ui/MetersPanel.h
@@ -1,0 +1,127 @@
+#pragma once
+#include <JuceHeader.h>
+#include <Charts/VerticalMeter.h>
+#include "GRMeter.h"
+
+/** MetersPanel: Organize per-band and master level meters with gain reduction display
+    Layout: Per-band input | GR | output meters, followed by master input | output
+    Designed for 2-band limiter (M1), ready to scale to N bands in M2 */
+class MetersPanel : public juce::Component
+{
+public:
+    MetersPanel()
+    {
+        // Create per-band meters (2 bands for M1)
+        for (int b = 0; b < 2; ++b)
+        {
+            // Input level meter
+            bandInputMeters.push_back(std::make_unique<VerticalMeter>());
+            bandInputMeters[b]->setName(juce::String("Band ") + juce::String(b + 1) + " In");
+            addAndMakeVisible(*bandInputMeters[b]);
+
+            // GR meter
+            bandGrMeters.push_back(std::make_unique<GRMeter>());
+            bandGrMeters[b]->setName(juce::String("Band ") + juce::String(b + 1) + " GR");
+            addAndMakeVisible(*bandGrMeters[b]);
+
+            // Output level meter
+            bandOutputMeters.push_back(std::make_unique<VerticalMeter>());
+            bandOutputMeters[b]->setName(juce::String("Band ") + juce::String(b + 1) + " Out");
+            addAndMakeVisible(*bandOutputMeters[b]);
+        }
+
+        // Master meters
+        masterInputMeter = std::make_unique<VerticalMeter>();
+        masterInputMeter->setName("Master In");
+        addAndMakeVisible(*masterInputMeter);
+
+        masterOutputMeter = std::make_unique<VerticalMeter>();
+        masterOutputMeter->setName("Master Out");
+        addAndMakeVisible(*masterOutputMeter);
+    }
+
+    void paint(juce::Graphics& g) override
+    {
+        g.fillAll(juce::Colour(0xFF1a1a1a));  // Dark background
+    }
+
+    void resized() override
+    {
+        auto bounds = getLocalBounds();
+        const int bandCount = 2;  // M1 constraint
+        const int meterWidth = 20;
+        const int spacing = 2;
+        const int grMeterWidth = 24;
+
+        // Calculate widths: (input + spacing + gr + spacing + output) per band + spacing + master
+        int x = 4;
+
+        // Per-band meters
+        for (int b = 0; b < bandCount; ++b)
+        {
+            // Input meter
+            bandInputMeters[b]->setBounds(x, 4, meterWidth, bounds.getHeight() - 8);
+            x += meterWidth + spacing;
+
+            // GR meter
+            bandGrMeters[b]->setBounds(x, 4, grMeterWidth, bounds.getHeight() - 8);
+            x += grMeterWidth + spacing;
+
+            // Output meter
+            bandOutputMeters[b]->setBounds(x, 4, meterWidth, bounds.getHeight() - 8);
+            x += meterWidth + spacing * 2;  // Extra spacing between bands
+        }
+
+        // Master meters (right side)
+        int masterX = bounds.getRight() - (meterWidth * 2) - spacing - 4;
+        masterInputMeter->setBounds(masterX, 4, meterWidth, bounds.getHeight() - 8);
+        masterOutputMeter->setBounds(masterX + meterWidth + spacing, 4, meterWidth, bounds.getHeight() - 8);
+    }
+
+    /** Feed per-band input levels (dBFS) */
+    void setBandInputDb(int bandIndex, float db)
+    {
+        if (bandIndex >= 0 && bandIndex < (int)bandInputMeters.size())
+            bandInputMeters[bandIndex]->setDb(db);
+    }
+
+    /** Feed per-band gain reduction levels (dB) */
+    void setBandGrDb(int bandIndex, float db)
+    {
+        if (bandIndex >= 0 && bandIndex < (int)bandGrMeters.size())
+            bandGrMeters[bandIndex]->setGRdB(db);
+    }
+
+    /** Feed per-band output levels (dBFS) */
+    void setBandOutputDb(int bandIndex, float db)
+    {
+        if (bandIndex >= 0 && bandIndex < (int)bandOutputMeters.size())
+            bandOutputMeters[bandIndex]->setDb(db);
+    }
+
+    /** Feed master input level (dBFS) */
+    void setMasterInputDb(float db)
+    {
+        if (masterInputMeter)
+            masterInputMeter->setDb(db);
+    }
+
+    /** Feed master output level (dBFS) */
+    void setMasterOutputDb(float db)
+    {
+        if (masterOutputMeter)
+            masterOutputMeter->setDb(db);
+    }
+
+private:
+    // Per-band meters (up to 6 for future expansion)
+    std::vector<std::unique_ptr<VerticalMeter>> bandInputMeters;
+    std::vector<std::unique_ptr<GRMeter>> bandGrMeters;
+    std::vector<std::unique_ptr<VerticalMeter>> bandOutputMeters;
+
+    // Master meters
+    std::unique_ptr<VerticalMeter> masterInputMeter;
+    std::unique_ptr<VerticalMeter> masterOutputMeter;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MetersPanel)
+};


### PR DESCRIPTION
Implemented UI metering for real-time level monitoring and gain reduction feedback.

**All files are from HungryGhostMultibandLimiter (Limiter plugin, NOT Compressor)**

Changes:
- GRMeter.h: Gain reduction meter with red-orange gradient
- MetersPanel.h: Organizes per-band and master level meters  
- PluginEditor integration: 60Hz timer updates for real-time feedback

Story: STORY-MBL-007 (metering for visual feedback)
Branch: feature/STORY-MBL-007-metering-ui